### PR TITLE
new option added - Easy Directory Navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.4 - Easy Directory Navigation option
+* Enabled by default : type '\' or '/' to navigate easily in highlighted directory (including parent directory)
+
 ## 0.1.0 - First Release
 * Every feature added
 * Every bug fixed

--- a/lib/file-explorer.coffee
+++ b/lib/file-explorer.coffee
@@ -10,21 +10,24 @@ module.exports =
     excludeActiveFile:
       type: 'boolean'
       default: true
-  
+    easyDirectoryNavigation:
+      type: 'boolean'
+      default: true
+
   FileExplorerView: null
 
   activate: (state) ->
     fileExplorerView = @createFileExplorerView()
-      
+
     atom.commands.add 'atom-text-editor', 'file-explorer:toggle-home-directory', =>
       @createFileExplorerView().toggleHomeDirectory()
 
     atom.commands.add 'atom-text-editor', 'file-explorer:toggle-current-directory', =>
       @createFileExplorerView().toggleCurrentDirectory()
-    
+
     atom.commands.add 'atom-text-editor', 'file-explorer:go-parent', =>
       @createFileExplorerView().goParent()
-    
+
 
   deactivate: ->
     @fileExplorer.destroy()
@@ -35,5 +38,5 @@ module.exports =
   createFileExplorerView: ->
     unless @fileExplorer?
       @fileExplorer = new FileExplorerView()
-      
+
     @fileExplorer

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "file-explorer",
   "main": "./lib/file-explorer",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "It provides SelectList View for accessing the project file and directory like fuzzy-finder.",
   "activationCommands": {
     "atom-text-editor": [


### PR DESCRIPTION
type '\' or '/' in filter box to go to currently highlighted directory
todo: prevent entering text '\' or '/' - am not sure how to do this, tried for an hour and let it at this point. 
